### PR TITLE
Update runtest.py

### DIFF
--- a/debian/tests/runtest.py
+++ b/debian/tests/runtest.py
@@ -10,7 +10,7 @@ async def test_aiofiles():
     assert('aiofiles' in contents)
 
 
-event_loop = asyncio.get_event_loop()
+event_loop = asyncio.get_event_loop_policy().get_event_loop()
 try:
     event_loop.run_until_complete(test_aiofiles())
 finally:


### PR DESCRIPTION
The autopkgtest for the is package is failing in Ubuntu with python-pytest-asyncio version 0.16.0-1 due to a DeprecationWarning which isn't a warning any more.

runtest.py           FAIL stderr: /tmp/autopkgtest.oaRXAD/build.jWo/src/debian/tests/runtest.py:13: DeprecationWarning: There is no current event loop

You can see the full log here:

https://autopkgtest.ubuntu.com/results/autopkgtest-jammy/jammy/amd64/a/aiofiles/20220127_070724_52ef6@/log.gz

This change fixes it and allows the test to run.